### PR TITLE
Readme edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # essai_PyQt
-apprentissage de IPython
+apprentissage de IPython; problèmes de configuration.
+sin on lance %matplotlib qt  on reçoit le message d'erreur
+
+File "C:\Users\Allebria\Anaconda3\lib\site-packages\matplotlib\backends\qt_compat.py", line 141 in <module>
+ from PyQt4 import QtCore, QtGui
+ModuleNotFoundError: No module named 'PyQt4'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # essai_PyQt
 apprentissage de IPython; problèmes de configuration.
-sin on lance %matplotlib qt  on reçoit le message d'erreur
+si l'on lance     %matplotlib qt   sur l'invite de IPython on reçoit le message d'erreur
 
 File "C:\Users\Allebria\Anaconda3\lib\site-packages\matplotlib\backends\qt_compat.py", line 141 in <module>
  from PyQt4 import QtCore, QtGui


### PR DESCRIPTION
Unsolved configuration problem with  spyder 3.1.4 and qtconsole 4.3.0 from ANACONDA 1.6.2  
Files dowloaded and installed in the standard Widows 7 system.

%matplotlib qt
.............
....\qt_compat.py in line 141 <module>
 from PyQt4 import QtCore, QtGui
ModuleNotFoundError: No module named 'PyQt4'

see error on attached module
 [qt_compat.pdf](https://github.com/Llebaria/essai_PyQt/files/1215364/qt_compat.pdf)


